### PR TITLE
Wifi Sensor path /tempdata and path variables default removed and now are required to be added to the sensorl URL. this will allow for differnt sensors with alternat paths.

### DIFF
--- a/src/main/java/com/brewery/core/WiFiThread.java
+++ b/src/main/java/com/brewery/core/WiFiThread.java
@@ -82,7 +82,7 @@ public class WiFiThread implements Runnable {
 					
 				    HttpEntity<String> request = new HttpEntity<>( "", headers);
 					
-				    URI uri = new URI( sensor.getUrl() + "/tempdata?responseFormat=JSON");
+				    URI uri = new URI( sensor.getUrl() );
 				    
 				    ResponseEntity<String> responseEnt = restTemplate.exchange( uri, HttpMethod.GET, request, String.class );
 				    String response = responseEnt.getBody();

--- a/src/main/java/com/brewery/service/WiFiService.java
+++ b/src/main/java/com/brewery/service/WiFiService.java
@@ -53,7 +53,7 @@ public class WiFiService {
             for (String ip : allIps ) {
             	if( checkIp( ip ) ) {
 	            	Sensor sensor = new Sensor();
-	            	sensor.setUrl( "http://" + ip ); 
+	            	sensor.setUrl( "http://" + ip + "/tempdata?responseFormat=JSON" ); 
 	            	sensor.setName( ip );
 	                sensors.add( sensor );
             	}


### PR DESCRIPTION
should be added to the sensor URL. This will allow for oter sensors with
different paths and path variables.